### PR TITLE
Change data URL for disabled parking

### DIFF
--- a/.codespell-ignore
+++ b/.codespell-ignore
@@ -1,0 +1,1 @@
+adresse

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,7 @@ repos:
         types: [text]
         exclude: ^poetry\.lock$
         entry: poetry run codespell
+        args: [--ignore-words=.codespell-ignore]
       - id: detect-private-key
         name: 🕵️  Detect Private Keys
         language: system

--- a/README.md
+++ b/README.md
@@ -52,14 +52,15 @@ There are a number of parameters you can set to retrieve the data:
 
 | Variable | Type | Description |
 | :------- | :--- | :---------- |
-| `entry_id` | integer | The ID of the parking spot |
-| `name` | string | The name of the parking spot |
+| `entry_id` | string | The ID of the parking spot |
 | `number` | integer | The number of parking spots on this location |
 | `address` | string | The address of the parking spot |
+| `district` | string | The district location of the parking spot |
 | `time_limit` | string | Some locations have window times where the location is only specific for disabled parking, outside these times everyone is allowed to park there |
 | `note` | string | Some locations have a note about the parking spot |
 | `longitude` | float | The longitude of the parking spot |
 | `latitude` | float | The latitude of the parking spot |
+| `last_update` | datetime | The last time the data was updated |
 
 ### Park and Rides
 

--- a/examples/disabled_parkings.py
+++ b/examples/disabled_parkings.py
@@ -9,13 +9,22 @@ from dusseldorf import ODPDusseldorf
 async def main() -> None:
     """Show example on using the Dusseldorf API client for disabled parkings."""
     async with ODPDusseldorf() as client:
-        disabled_parkings = await client.disabled_parkings(limit=10)
+        disabled_parkings = await client.disabled_parkings()
 
         count: int
         for index, item in enumerate(disabled_parkings, 1):
             count = index
             print(item)
-        print(f"{count} locations found")
+
+        # Count unique id's in disabled_parkings
+        unique_values: list[str] = []
+        for item in disabled_parkings:
+            unique_values.append(str(item.entry_id))
+        num_values = len(set(unique_values))
+
+        print("__________________________")
+        print(f"Total locations found: {count}")
+        print(f"Unique ID values: {num_values}")
 
 
 if __name__ == "__main__":

--- a/examples/garages.py
+++ b/examples/garages.py
@@ -15,7 +15,9 @@ async def main() -> None:
         for index, item in enumerate(garages, 1):
             count = index
             print(item)
-        print(f"{count} locations found")
+
+        print("__________________________")
+        print(f"Total locations found: {count}")
 
 
 if __name__ == "__main__":

--- a/examples/parkandrides.py
+++ b/examples/parkandrides.py
@@ -15,7 +15,9 @@ async def main() -> None:
         for index, item in enumerate(park_and_rides, 1):
             count = index
             print(item)
-        print(f"{count} locations found")
+
+        print("__________________________")
+        print(f"Total locations found: {count}")
 
 
 if __name__ == "__main__":

--- a/src/dusseldorf/models.py
+++ b/src/dusseldorf/models.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 
 
@@ -49,14 +50,16 @@ class ParkAndRide:
 class DisabledParking:
     """Object representing a DisabledParking."""
 
-    entry_id: int
-    name: str
+    entry_id: str
     number: int
     address: str
+    district: str
     time_limit: str | None
     note: str | None
+
     longitude: float
     latitude: float
+    last_update: datetime
 
     @classmethod
     def from_dict(cls: type[DisabledParking], data: dict[str, Any]) -> DisabledParking:
@@ -70,18 +73,21 @@ class DisabledParking:
         -------
             A DisabledParking object.
         """
+        attr = data["properties"]
+        coordinates = data["geometry"]["coordinates"]
         return cls(
-            entry_id=int(data["entry_id"]),
-            name=data["name"],
-            number=int(data["anzahl"]),
-            address=set_address(
-                data["strasse"],
-                data["hausnr"],
-            ),
-            time_limit=data.get("zeitbegrenzung") or None,
-            note=data.get("bemerkung") or None,
-            longitude=float(data["longitude"]),
-            latitude=float(data["latitude"]),
+            entry_id=data["id"].replace("behindertenparkplatz.", ""),
+            number=int(attr["anzahl"][:2]),
+            address=attr["adresse"].strip(),
+            district=attr["stadtteil"],
+            time_limit=attr.get("zeitbegrenzung") or None,
+            note=attr.get("beschreibung") or None,
+            longitude=float(coordinates[0]),
+            latitude=float(coordinates[1]),
+            last_update=datetime.strptime(
+                attr["_last_update"],
+                "%Y-%m-%d",
+            ).astimezone(),
         )
 
 

--- a/tests/fixtures/disabled_parkings-old.json
+++ b/tests/fixtures/disabled_parkings-old.json
@@ -1,0 +1,203 @@
+{
+    "help": "Search a datastore table. :param resource_id: id or alias of the data that is going to be selected.",
+    "success": true,
+    "result": {
+        "fields": [
+            {
+                "id": "latitude",
+                "type": "text"
+            },
+            {
+                "id": "longitude",
+                "type": "text"
+            },
+            {
+                "id": "altitude",
+                "type": "text"
+            },
+            {
+                "id": "geometry",
+                "type": "text"
+            },
+            {
+                "id": "strasse",
+                "type": "text"
+            },
+            {
+                "id": "hausnr",
+                "type": "text"
+            },
+            {
+                "id": "zusatzid",
+                "type": "text"
+            },
+            {
+                "id": "bemerkung",
+                "type": "text"
+            },
+            {
+                "id": "name",
+                "type": "text"
+            },
+            {
+                "id": "anzahl",
+                "type": "text"
+            },
+            {
+                "id": "zeitbegrenzung",
+                "type": "text"
+            },
+            {
+                "id": "entry_id",
+                "type": "serial"
+            }
+        ],
+        "resource_id": [
+            "995914c7-4275-49c4-8441-426722336c3a"
+        ],
+        "limit": 10,
+        "total": 315,
+        "records": [
+            {
+                "latitude": "51.2251646517767",
+                "longitude": "6.79668628804256",
+                "altitude": "0",
+                "geometry": "point",
+                "strasse": "Ackerstraße",
+                "hausnr": "8",
+                "zusatzid": "",
+                "bemerkung": "",
+                "name": "Innenstadt / Worringer Platz",
+                "anzahl": "1",
+                "zeitbegrenzung": "",
+                "entry_id": "1"
+            },
+            {
+                "latitude": "51.2296990437696",
+                "longitude": "6.80654593218891",
+                "altitude": "0",
+                "geometry": "point",
+                "strasse": "Ackerstraße",
+                "hausnr": "150",
+                "zusatzid": "",
+                "bemerkung": "",
+                "name": "Arztpraxis",
+                "anzahl": "1",
+                "zeitbegrenzung": "Mo. - Fr.  8 - 12:00",
+                "entry_id": "2"
+            },
+            {
+                "latitude": "51.2304160351845",
+                "longitude": "6.80910542259138",
+                "altitude": "0",
+                "geometry": "point",
+                "strasse": "Ackerstraße",
+                "hausnr": "199",
+                "zusatzid": "",
+                "bemerkung": "",
+                "name": "Orthopädie Schuhtechnik",
+                "anzahl": "1",
+                "zeitbegrenzung": "Mo. - Fr.  9 - 18:00",
+                "entry_id": "3"
+            },
+            {
+                "latitude": "51.2182622227472",
+                "longitude": "6.77797033443116",
+                "altitude": "0",
+                "geometry": "point",
+                "strasse": "Adersstraße",
+                "hausnr": "",
+                "zusatzid": "",
+                "bemerkung": "",
+                "name": "LVA",
+                "anzahl": "3",
+                "zeitbegrenzung": "Mo. - Fr.  7 - 14:00",
+                "entry_id": "4"
+            },
+            {
+                "latitude": "51.237650",
+                "longitude": "6.798331",
+                "altitude": "0",
+                "geometry": "point",
+                "strasse": "Ahnfeldplatz",
+                "hausnr": "",
+                "zusatzid": "",
+                "bemerkung": "",
+                "name": "Einkaufszentrum",
+                "anzahl": "1",
+                "zeitbegrenzung": "",
+                "entry_id": "5"
+            },
+            {
+                "latitude": "51.2748360666959",
+                "longitude": "6.78237575010322",
+                "altitude": "0",
+                "geometry": "point",
+                "strasse": "Ahornallee",
+                "hausnr": "5a",
+                "zusatzid": "",
+                "bemerkung": "",
+                "name": "Kindertagesstätte",
+                "anzahl": "1",
+                "zeitbegrenzung": "Mo. - Fr.  7 - 16:00",
+                "entry_id": "6"
+            },
+            {
+                "latitude": "51.291102",
+                "longitude": "6.788809",
+                "altitude": "0",
+                "geometry": "point",
+                "strasse": "Ahrensplatz",
+                "hausnr": "",
+                "zusatzid": "",
+                "bemerkung": "",
+                "name": "Flughafen / Bahnhof",
+                "anzahl": "2",
+                "zeitbegrenzung": "",
+                "entry_id": "7"
+            },
+            {
+                "latitude": "51.2331953690443",
+                "longitude": "6.70534109033413",
+                "altitude": "0",
+                "geometry": "point",
+                "strasse": "Aldekerkstraße",
+                "hausnr": "37",
+                "zusatzid": "",
+                "bemerkung": "",
+                "name": "Begegnungsstätte Diakonie",
+                "anzahl": "1",
+                "zeitbegrenzung": "",
+                "entry_id": "8"
+            },
+            {
+                "latitude": "51.2919882439447",
+                "longitude": "6.74020831619918",
+                "altitude": "0",
+                "geometry": "point",
+                "strasse": "Alte Landstraße",
+                "hausnr": "79",
+                "zusatzid": "",
+                "bemerkung": "",
+                "name": "Arztpraxis",
+                "anzahl": "1",
+                "zeitbegrenzung": "Mo. - Fr.  7 - 19:00",
+                "entry_id": "9"
+            },
+            {
+                "latitude": "51.3009225778847",
+                "longitude": "6.7415756546544",
+                "altitude": "0",
+                "geometry": "point",
+                "strasse": "Alte Landstraße",
+                "hausnr": "188h",
+                "zusatzid": "gegenüber",
+                "bemerkung": "",
+                "name": "Einkaufszentrum",
+                "anzahl": "1",
+                "zeitbegrenzung": "",
+                "entry_id": "10"
+            }
+        ]
+    }
+}

--- a/tests/fixtures/disabled_parkings.json
+++ b/tests/fixtures/disabled_parkings.json
@@ -1,203 +1,245 @@
 {
-    "help": "Search a datastore table. :param resource_id: id or alias of the data that is going to be selected.",
-    "success": true,
-    "result": {
-        "fields": [
-            {
-                "id": "latitude",
-                "type": "text"
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "id": "behindertenparkplatz.a29702e7-94ae-4556-8e83-b57e8368f7c9",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    6.85161382,
+                    51.17041525
+                ]
             },
-            {
-                "id": "longitude",
-                "type": "text"
-            },
-            {
-                "id": "altitude",
-                "type": "text"
-            },
-            {
-                "id": "geometry",
-                "type": "text"
-            },
-            {
-                "id": "strasse",
-                "type": "text"
-            },
-            {
-                "id": "hausnr",
-                "type": "text"
-            },
-            {
-                "id": "zusatzid",
-                "type": "text"
-            },
-            {
-                "id": "bemerkung",
-                "type": "text"
-            },
-            {
-                "id": "name",
-                "type": "text"
-            },
-            {
-                "id": "anzahl",
-                "type": "text"
-            },
-            {
-                "id": "zeitbegrenzung",
-                "type": "text"
-            },
-            {
-                "id": "entry_id",
-                "type": "serial"
+            "geometry_name": "_geometry",
+            "properties": {
+                "_dic_id": "behplz",
+                "beschreibung": "Stadtbad Niederheid",
+                "zeitbegrenzung": null,
+                "anzahl": "4 Stellplätze",
+                "adresse": "Paul-Thomas-Straße 35 ",
+                "plz": "40589",
+                "stadtteil": "Holthausen",
+                "stadt": "Düsseldorf",
+                "_last_update": "2022-10-28"
             }
-        ],
-        "resource_id": [
-            "995914c7-4275-49c4-8441-426722336c3a"
-        ],
-        "limit": 10,
-        "total": 315,
-        "records": [
-            {
-                "latitude": "51.2251646517767",
-                "longitude": "6.79668628804256",
-                "altitude": "0",
-                "geometry": "point",
-                "strasse": "Ackerstraße",
-                "hausnr": "8",
-                "zusatzid": "",
-                "bemerkung": "",
-                "name": "Innenstadt / Worringer Platz",
-                "anzahl": "1",
-                "zeitbegrenzung": "",
-                "entry_id": "1"
+        },
+        {
+            "type": "Feature",
+            "id": "behindertenparkplatz.eec91bb1-95ae-4be4-8c10-c34e95b1a9a7",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    6.88558867,
+                    51.14448552
+                ]
             },
-            {
-                "latitude": "51.2296990437696",
-                "longitude": "6.80654593218891",
-                "altitude": "0",
-                "geometry": "point",
-                "strasse": "Ackerstraße",
-                "hausnr": "150",
-                "zusatzid": "",
-                "bemerkung": "",
-                "name": "Arztpraxis",
-                "anzahl": "1",
-                "zeitbegrenzung": "Mo. - Fr.  8 - 12:00",
-                "entry_id": "2"
-            },
-            {
-                "latitude": "51.2304160351845",
-                "longitude": "6.80910542259138",
-                "altitude": "0",
-                "geometry": "point",
-                "strasse": "Ackerstraße",
-                "hausnr": "199",
-                "zusatzid": "",
-                "bemerkung": "",
-                "name": "Orthopädie Schuhtechnik",
-                "anzahl": "1",
-                "zeitbegrenzung": "Mo. - Fr.  9 - 18:00",
-                "entry_id": "3"
-            },
-            {
-                "latitude": "51.2182622227472",
-                "longitude": "6.77797033443116",
-                "altitude": "0",
-                "geometry": "point",
-                "strasse": "Adersstraße",
-                "hausnr": "",
-                "zusatzid": "",
-                "bemerkung": "",
-                "name": "LVA",
-                "anzahl": "3",
-                "zeitbegrenzung": "Mo. - Fr.  7 - 14:00",
-                "entry_id": "4"
-            },
-            {
-                "latitude": "51.237650",
-                "longitude": "6.798331",
-                "altitude": "0",
-                "geometry": "point",
-                "strasse": "Ahnfeldplatz",
-                "hausnr": "",
-                "zusatzid": "",
-                "bemerkung": "",
-                "name": "Einkaufszentrum",
-                "anzahl": "1",
-                "zeitbegrenzung": "",
-                "entry_id": "5"
-            },
-            {
-                "latitude": "51.2748360666959",
-                "longitude": "6.78237575010322",
-                "altitude": "0",
-                "geometry": "point",
-                "strasse": "Ahornallee",
-                "hausnr": "5a",
-                "zusatzid": "",
-                "bemerkung": "",
-                "name": "Kindertagesstätte",
-                "anzahl": "1",
-                "zeitbegrenzung": "Mo. - Fr.  7 - 16:00",
-                "entry_id": "6"
-            },
-            {
-                "latitude": "51.291102",
-                "longitude": "6.788809",
-                "altitude": "0",
-                "geometry": "point",
-                "strasse": "Ahrensplatz",
-                "hausnr": "",
-                "zusatzid": "",
-                "bemerkung": "",
-                "name": "Flughafen / Bahnhof",
-                "anzahl": "2",
-                "zeitbegrenzung": "",
-                "entry_id": "7"
-            },
-            {
-                "latitude": "51.2331953690443",
-                "longitude": "6.70534109033413",
-                "altitude": "0",
-                "geometry": "point",
-                "strasse": "Aldekerkstraße",
-                "hausnr": "37",
-                "zusatzid": "",
-                "bemerkung": "",
-                "name": "Begegnungsstätte Diakonie",
-                "anzahl": "1",
-                "zeitbegrenzung": "",
-                "entry_id": "8"
-            },
-            {
-                "latitude": "51.2919882439447",
-                "longitude": "6.74020831619918",
-                "altitude": "0",
-                "geometry": "point",
-                "strasse": "Alte Landstraße",
-                "hausnr": "79",
-                "zusatzid": "",
-                "bemerkung": "",
-                "name": "Arztpraxis",
-                "anzahl": "1",
-                "zeitbegrenzung": "Mo. - Fr.  7 - 19:00",
-                "entry_id": "9"
-            },
-            {
-                "latitude": "51.3009225778847",
-                "longitude": "6.7415756546544",
-                "altitude": "0",
-                "geometry": "point",
-                "strasse": "Alte Landstraße",
-                "hausnr": "188h",
-                "zusatzid": "gegenüber",
-                "bemerkung": "",
-                "name": "Einkaufszentrum",
-                "anzahl": "1",
-                "zeitbegrenzung": "",
-                "entry_id": "10"
+            "geometry_name": "_geometry",
+            "properties": {
+                "_dic_id": "behplz",
+                "beschreibung": "Einkaufszentrum",
+                "zeitbegrenzung": null,
+                "anzahl": "2 Stellplätze",
+                "adresse": "Peter-Behrens-Straße 2 ",
+                "plz": "40595",
+                "stadtteil": "Garath",
+                "stadt": "Düsseldorf",
+                "_last_update": "2022-10-28"
             }
-        ]
+        },
+        {
+            "type": "Feature",
+            "id": "behindertenparkplatz.e9616d07-69a2-4e1c-9efd-48ddb0351dfd",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    6.78565818,
+                    51.21858693
+                ]
+            },
+            "geometry_name": "_geometry",
+            "properties": {
+                "_dic_id": "behplz",
+                "beschreibung": "Arztpraxis",
+                "zeitbegrenzung": null,
+                "anzahl": "1 Stellplatz",
+                "adresse": "Pionierstraße 1 ",
+                "plz": "40215",
+                "stadtteil": "Friedrichstadt",
+                "stadt": "Düsseldorf",
+                "_last_update": "2022-10-28"
+            }
+        },
+        {
+            "type": "Feature",
+            "id": "behindertenparkplatz.119bc152-9ace-4f7a-8228-7fefe3c6f791",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    6.83597885,
+                    51.23818121
+                ]
+            },
+            "geometry_name": "_geometry",
+            "properties": {
+                "_dic_id": "behplz",
+                "beschreibung": "mehrere Berechtigte/Wohngebiet",
+                "zeitbegrenzung": null,
+                "anzahl": "1 Stellplatz",
+                "adresse": "Pöhlenweg 41 ",
+                "plz": "40629",
+                "stadtteil": "Grafenberg",
+                "stadt": "Düsseldorf",
+                "_last_update": "2022-10-28"
+            }
+        },
+        {
+            "type": "Feature",
+            "id": "behindertenparkplatz.a9c27189-1c56-4520-9492-582bcfc22b31",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    6.83048486,
+                    51.20878751
+                ]
+            },
+            "geometry_name": "_geometry",
+            "properties": {
+                "_dic_id": "behplz",
+                "beschreibung": "Kirche",
+                "zeitbegrenzung": null,
+                "anzahl": "2 Stellplätze",
+                "adresse": "Posener Straße  ",
+                "plz": "40231",
+                "stadtteil": "Lierenfeld",
+                "stadt": "Düsseldorf",
+                "_last_update": "2022-10-28"
+            }
+        },
+        {
+            "type": "Feature",
+            "id": "behindertenparkplatz.4188a370-9bb6-4dbf-8daf-1bd464d9b9a3",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    6.77169835,
+                    51.22297154
+                ]
+            },
+            "geometry_name": "_geometry",
+            "properties": {
+                "_dic_id": "behplz",
+                "beschreibung": "Maxkirche / Carlsplatz",
+                "zeitbegrenzung": null,
+                "anzahl": "1 Stellplatz",
+                "adresse": "Poststraße 1 ",
+                "plz": "40213",
+                "stadtteil": "Carlstadt",
+                "stadt": "Düsseldorf",
+                "_last_update": "2022-10-28"
+            }
+        },
+        {
+            "type": "Feature",
+            "id": "behindertenparkplatz.1fa87962-5cd3-4442-b148-85fa6d87693c",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    6.86189224,
+                    51.18448969
+                ]
+            },
+            "geometry_name": "_geometry",
+            "properties": {
+                "_dic_id": "behplz",
+                "beschreibung": "DRK",
+                "zeitbegrenzung": "Mo.-So. 8:00-18:00",
+                "anzahl": "1 Stellplatz",
+                "adresse": "Potsdamer Straße 39 ",
+                "plz": "40599",
+                "stadtteil": "Hassels",
+                "stadt": "Düsseldorf",
+                "_last_update": "2022-10-28"
+            }
+        },
+        {
+            "type": "Feature",
+            "id": "behindertenparkplatz.c4275963-5d4f-4208-ab12-2da7f501c115",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    6.7345448,
+                    51.23699852
+                ]
+            },
+            "geometry_name": "_geometry",
+            "properties": {
+                "_dic_id": "behplz",
+                "beschreibung": "Ärztehaus",
+                "zeitbegrenzung": null,
+                "anzahl": "1 Stellplatz",
+                "adresse": "Prinzenallee 19 ",
+                "plz": "40549",
+                "stadtteil": "Heerdt",
+                "stadt": "Düsseldorf",
+                "_last_update": "2022-10-28"
+            }
+        },
+        {
+            "type": "Feature",
+            "id": "behindertenparkplatz.595db356-0e41-4014-8702-6e8d975f0a95",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    6.86591546,
+                    51.23212988
+                ]
+            },
+            "geometry_name": "_geometry",
+            "properties": {
+                "_dic_id": "behplz",
+                "beschreibung": "Friedhof",
+                "zeitbegrenzung": null,
+                "anzahl": "2 Stellplätze",
+                "adresse": "Quadenhofstraße  ",
+                "plz": "40625",
+                "stadtteil": "Gerresheim",
+                "stadt": "Düsseldorf",
+                "_last_update": "2022-10-28"
+            }
+        },
+        {
+            "type": "Feature",
+            "id": "behindertenparkplatz.a7bc2fcf-072c-4b9f-8cf4-26f39890029e",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    6.75015157,
+                    51.23366626
+                ]
+            },
+            "geometry_name": "_geometry",
+            "properties": {
+                "_dic_id": "behplz",
+                "beschreibung": "vor der Kirche",
+                "zeitbegrenzung": null,
+                "anzahl": "1 Stellplatz",
+                "adresse": "Quirinstraße 32 ",
+                "plz": "40545",
+                "stadtteil": "Oberkassel",
+                "stadt": "Düsseldorf",
+                "_last_update": "2022-10-28"
+            }
+        }
+    ],
+    "totalFeatures": 10,
+    "numberMatched": 10,
+    "numberReturned": 10,
+    "timeStamp": "2023-06-29T09:16:15.932Z",
+    "crs": {
+        "type": "name",
+        "properties": {
+            "name": "urn:ogc:def:crs:EPSG::4326"
+        }
     }
 }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,6 @@
 """Test the models."""
+from datetime import datetime
+
 from aiohttp import ClientSession
 from aresponses import ResponsesMockServer
 
@@ -62,8 +64,8 @@ async def test_all_park_and_rides(aresponses: ResponsesMockServer) -> None:
 async def test_all_disabled_parkings(aresponses: ResponsesMockServer) -> None:
     """Test park and ride spaces function."""
     aresponses.add(
-        "opendata.duesseldorf.de",
-        "/api/action/datastore/search.json",
+        "maps.duesseldorf.de",
+        "/services/verkehr/wfs",
         "GET",
         aresponses.Response(
             status=200,
@@ -77,9 +79,9 @@ async def test_all_disabled_parkings(aresponses: ResponsesMockServer) -> None:
         assert spaces is not None
         for item in spaces:
             assert isinstance(item, DisabledParking)
-            assert isinstance(item.entry_id, int)
+            assert isinstance(item.entry_id, str)
             assert item.entry_id is not None
-            assert isinstance(item.name, str)
             assert item.number is not None
             assert isinstance(item.longitude, float)
             assert isinstance(item.latitude, float)
+            assert isinstance(item.last_update, datetime)


### PR DESCRIPTION
## Proposed change
<!--
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the
    additional information section.
-->

With this PR, the data about disabled parkings is now retrieved from another URL.

As a result, there is a breaking change on the model properties:
- `name` is no longer available
- You can no longer set a `limit` in the number of results
- Added new data such as `district` name and `last_update`
- `entry_id` is now a string and not an int

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #157 

## Checklist
<!--
    Go over all the following points, and put an `x` in all the boxes that apply.
    If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [X] I have updated the documentation if needed.
- [X] I have updated the tests if needed.
